### PR TITLE
Better argument validation in *-dev script

### DIFF
--- a/bin/bosh-create
+++ b/bin/bosh-create
@@ -663,9 +663,19 @@ case \${action} in
     prepare_blobs
     ;;
   (stemcell)
+    if (( \${#args[@]} == 0 ))
+    then
+      usage
+      fail
+    fi
     prepare_stemcell "\${args[@]}"
     ;;
   (manifest)
+    if (( \${#args[@]} == 0 ))
+    then
+      usage
+      fail
+    fi
     prepare_manifest "\${args[@]}"
     ;;
   (destroy|delete)


### PR DESCRIPTION
The './x-dev stemcell' and './x-dev manifest' actions require an
argument, and should do validation to ensure that it is passed by the
caller, to avoid obscure bash error messages later.
